### PR TITLE
feat: add Lloyd-Max codebook generation (1-8 bit scalar quantization)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+docs/prompts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] — TBD
+## [0.3.0] — TBD
+
+### Added
+
+- `codebook` module — Lloyd-Max optimal scalar quantization codebook
+  for the Beta(1/2, (d-1)/2) coordinate marginal of unit-sphere vectors
+  - `Codebook` struct with `quantize` / `dequantize` (f32 storage)
+  - `generate_codebook(dim, bit_width, iterations)` — 1–8 bit support
+  - `CodebookCache` — memoizing cache keyed by (dim, bit_width)
+- `math` module — numerical helpers (all f64 internals)
+  - `lgamma` — Lanczos approximation
+  - `beta_pdf` — coordinate marginal PDF with Gaussian path for dim > 50
+  - `normal_icdf` — Beasley-Springer-Moro rational approximation
+  - `sample_beta_marginal` — inverse CDF via bisection / Gaussian
+  - `simpson_integrate` — paired Simpson's rule
+- `QjlError::InvalidCodebookBitWidth` and `QjlError::InvalidDimension` variants
+- `THIRD_PARTY_NOTICES` file (TurboQuant MIT attribution)
+- 30 new tests (14 codebook + 12 math + 4 error)
+
+### Fixed
+
+- 15 rustdoc `broken_intra_doc_links` warnings across existing modules
+  (escaped `[brackets]` in doc comments)
+
+## [0.2.0] — 2025-07-23
 
 **Breaking change:** all public functions now return `Result<T, QjlError>`
 instead of panicking on invalid input.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qjl-sketch"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.95"
 description = "QJL sign-based vector compression and scoring with near-optimal distortion rate"

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,33 @@
+# Third-Party Notices
+
+## TurboQuant
+
+The Lloyd-Max codebook generation in `src/codebook.rs` and the math
+helpers in `src/math.rs` were inspired by the TurboQuant project.
+
+- Repository: https://github.com/abdelstark/turboquant
+- License: MIT
+
+```
+MIT License
+
+Copyright (c) 2024 TurboQuant Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Architecture and implementation decisions.
 
 | Document                                       | What it covers                                                  |
 | ---------------------------------------------- | --------------------------------------------------------------- |
-| [design/algorithms.md](design/algorithms.md)   | 7 algorithms extracted from QJL reference, Rust data structures |
+| [design/algorithms.md](design/algorithms.md)   | 8 algorithms: QJL projection through Lloyd-Max codebook          |
 | [design/persistence.md](design/persistence.md) | Two-store file format, mmap loading, compaction                 |
 | [design/store.md](design/store.md)             | Store API usage, lifecycle, error handling, crash safety        |
 | [design/benchmarks.md](design/benchmarks.md)   | Benchmark suite, baseline results, optimization targets         |

--- a/docs/design/algorithms.md
+++ b/docs/design/algorithms.md
@@ -12,7 +12,9 @@ src/
 ├── quantize.rs     CompressedKeys — sign hashing, bit-packing
 ├── score.rs        score — signed dot, outlier sketch subtraction
 ├── values.rs       CompressedValues — min-max quantization, fused matmul
-└── quantizer.rs    KeyQuantizer — batch + streaming wrapper
+├── quantizer.rs    KeyQuantizer — batch + streaming wrapper
+├── math.rs         Numerical helpers — lgamma, beta_pdf, normal_icdf, Simpson's rule
+└── codebook.rs     Codebook — Lloyd-Max optimal scalar quantization
 ```
 
 ## Algorithm 1: Random Projection Matrix
@@ -208,7 +210,48 @@ Algorithm:
     acc += weights[i] * float_val
 ```
 
-## Algorithm 7: Streaming Quantizer
+## Algorithm 7: Lloyd-Max Codebook Generation
+
+Source: Lloyd 1982 / Max 1960 (textbook optimal scalar quantization).
+Impl: `src/codebook.rs` → `generate_codebook`, `src/math.rs` → helpers.
+
+Generates an optimal scalar quantization codebook for the coordinate
+marginal distribution of a d-dimensional unit-sphere-uniform vector.
+
+```
+Input:
+  dim        = vector dimension (determines the marginal distribution)
+  bit_width  = bits per scalar (1..=8, giving 2^bit_width levels)
+  iterations = max Lloyd-Max iterations (typically 50–100)
+
+Output:
+  centroids  : [2^bit_width] f32  — reconstruction values
+  boundaries : [2^bit_width - 1] f32  — decision thresholds
+
+Algorithm:
+  1. Initialize centroids via quantile spacing of Beta(1/2, (d-1)/2):
+       c_i = F⁻¹((i + 0.5) / k)  for i in 0..k, where k = 2^bit_width
+  2. Lloyd-Max iterations (until convergence or max iterations):
+     a. Update boundaries as midpoints:
+          b_i = (c_i + c_{i+1}) / 2
+     b. Update centroids as conditional means:
+          c_i = E[X | b_{i-1} ≤ X < b_i]
+        computed via Simpson's rule numerical integration
+     c. Stop when max |c_new - c_old| < 1e-12
+  3. Final boundaries recomputed from converged centroids
+
+Marginal PDF:
+  f(x) = C_d · (1 - x²)^((d-3)/2)  for |x| < 1, d ≤ 50
+  f(x) ≈ N(0, 1/d)                   for d > 50
+```
+
+Computation is done in f64 for numerical stability; the returned
+codebook stores f32 centroids and boundaries.
+
+`CodebookCache` memoizes codebooks by (dim, bit_width) to avoid
+recomputation.
+
+## Algorithm 8: Streaming Quantizer
 
 Source: `QJLKeyQuantizer.update_sketch` in `llama3_utils_qjl.py`
 Impl: `src/quantizer.rs` → `KeyQuantizer`
@@ -254,6 +297,13 @@ pub struct CompressedKeys {
     pub outlier_indices: Vec<u8>,     // [outlier_count] per group
     pub num_vectors: usize,
     pub head_dim: usize,
+}
+
+// src/codebook.rs
+pub struct Codebook {
+    pub centroids: Vec<f32>,          // [2^bit_width] reconstruction values
+    pub boundaries: Vec<f32>,         // [2^bit_width - 1] decision thresholds
+    pub bit_width: u8,                // 1..=8
 }
 
 // src/values.rs

--- a/src/codebook.rs
+++ b/src/codebook.rs
@@ -1,0 +1,285 @@
+// Lloyd-Max codebook generation for scalar quantization of
+// unit-sphere coordinate marginals.
+//
+// Inspired by turboquant (MIT, https://github.com/abdelstark/turboquant).
+// Algorithm: Lloyd 1982 / Max 1960 — textbook optimal scalar quantization.
+
+use std::collections::HashMap;
+
+use crate::error::{QjlError, Result};
+use crate::math::{beta_pdf, sample_beta_marginal, simpson_integrate};
+
+/// A Lloyd-Max optimal scalar quantization codebook.
+///
+/// Stores 2^bit_width centroids (reconstruction values) and
+/// 2^bit_width - 1 decision boundaries, optimized for the Beta(1/2, (d-1)/2)
+/// coordinate marginal of unit-sphere-uniform vectors.
+#[derive(Debug, Clone)]
+pub struct Codebook {
+    /// Quantization centroids (reconstruction values), length = 2^bit_width.
+    pub centroids: Vec<f32>,
+    /// Decision boundaries between adjacent centroids, length = 2^bit_width - 1.
+    pub boundaries: Vec<f32>,
+    /// Number of bits per scalar.
+    pub bit_width: u8,
+}
+
+impl Codebook {
+    /// Number of quantization levels.
+    pub fn num_levels(&self) -> usize {
+        self.centroids.len()
+    }
+
+    /// Quantize a scalar value to its codebook index via binary search.
+    pub fn quantize(&self, value: f32) -> u8 {
+        if value.is_nan() {
+            return 0;
+        }
+        let v = value as f64;
+        match self.boundaries.binary_search_by(|b| {
+            (*b as f64)
+                .partial_cmp(&v)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }) {
+            Ok(i) => i as u8,
+            Err(i) => i.min(self.centroids.len() - 1) as u8,
+        }
+    }
+
+    /// Reconstruct the centroid value for a codebook index.
+    pub fn dequantize(&self, index: u8) -> f32 {
+        self.centroids[index as usize]
+    }
+}
+
+/// Generate a Lloyd-Max optimal codebook for dimension `dim` with
+/// `bit_width` bits per scalar (1..=8) using up to `iterations` refinement steps.
+///
+/// Computation is done in f64 for numerical stability; the returned
+/// codebook stores f32 centroids and boundaries.
+pub fn generate_codebook(dim: usize, bit_width: u8, iterations: usize) -> Result<Codebook> {
+    if !(1..=8).contains(&bit_width) {
+        return Err(QjlError::InvalidCodebookBitWidth(bit_width));
+    }
+    if dim == 0 {
+        return Err(QjlError::InvalidDimension(dim));
+    }
+
+    let k = 1usize << bit_width;
+
+    // Initialize centroids via quantile spacing of the marginal distribution.
+    let mut centroids: Vec<f64> = (0..k)
+        .map(|i| sample_beta_marginal(dim, (i as f64 + 0.5) / k as f64))
+        .collect();
+    centroids.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    for _ in 0..iterations {
+        let boundaries: Vec<f64> = centroids.windows(2).map(|w| (w[0] + w[1]) / 2.0).collect();
+
+        let new_centroids = compute_centroids(&centroids, &boundaries, dim);
+
+        let converged = centroids
+            .iter()
+            .zip(new_centroids.iter())
+            .all(|(a, b)| (a - b).abs() < 1e-12);
+
+        centroids = new_centroids;
+        if converged {
+            break;
+        }
+    }
+
+    let boundaries: Vec<f64> = centroids.windows(2).map(|w| (w[0] + w[1]) / 2.0).collect();
+
+    Ok(Codebook {
+        centroids: centroids.iter().map(|&c| c as f32).collect(),
+        boundaries: boundaries.iter().map(|&b| b as f32).collect(),
+        bit_width,
+    })
+}
+
+/// Compute conditional-mean centroids E[X | region] for each Voronoi cell.
+fn compute_centroids(old: &[f64], boundaries: &[f64], dim: usize) -> Vec<f64> {
+    let k = old.len();
+    let n_points = 200;
+
+    (0..k)
+        .map(|i| {
+            let lo = if i == 0 { -1.0 } else { boundaries[i - 1] }.max(-0.9999);
+            let hi = if i == k - 1 { 1.0 } else { boundaries[i] }.min(0.9999);
+
+            if hi <= lo {
+                return old[i];
+            }
+
+            let (num, den) = simpson_integrate(lo, hi, n_points, |x| {
+                let pdf = beta_pdf(x, dim);
+                (x * pdf, pdf)
+            });
+
+            if den.abs() < 1e-15 {
+                old[i]
+            } else {
+                num / den
+            }
+        })
+        .collect()
+}
+
+/// Memoizing cache for codebooks, keyed by (dim, bit_width).
+pub struct CodebookCache {
+    books: HashMap<(usize, u8), Codebook>,
+}
+
+impl CodebookCache {
+    pub fn new() -> Self {
+        Self {
+            books: HashMap::new(),
+        }
+    }
+
+    /// Get a cached codebook or generate one (100 Lloyd-Max iterations).
+    pub fn get_or_generate(&mut self, dim: usize, bit_width: u8) -> Result<&Codebook> {
+        let key = (dim, bit_width);
+        if let std::collections::hash_map::Entry::Vacant(e) = self.books.entry(key) {
+            e.insert(generate_codebook(dim, bit_width, 100)?);
+        }
+        Ok(&self.books[&key])
+    }
+}
+
+impl Default for CodebookCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codebook_1bit_symmetric() {
+        let cb = generate_codebook(128, 1, 50).unwrap();
+        assert_eq!(cb.centroids.len(), 2);
+        assert_eq!(cb.boundaries.len(), 1);
+        assert!((cb.centroids[0] + cb.centroids[1]).abs() < 1e-6);
+        assert!(cb.boundaries[0].abs() < 1e-6);
+    }
+
+    #[test]
+    fn codebook_4bit_sorted() {
+        let cb = generate_codebook(128, 4, 100).unwrap();
+        assert_eq!(cb.centroids.len(), 16);
+        assert_eq!(cb.boundaries.len(), 15);
+        for w in cb.centroids.windows(2) {
+            assert!(w[0] < w[1]);
+        }
+    }
+
+    #[test]
+    fn codebook_centroids_in_range() {
+        let cb = generate_codebook(32, 2, 50).unwrap();
+        for c in &cb.centroids {
+            assert!(*c > -1.0 && *c < 1.0, "centroid {c} out of range");
+        }
+    }
+
+    #[test]
+    fn codebook_boundaries_between_centroids() {
+        let cb = generate_codebook(64, 2, 50).unwrap();
+        for (i, &b) in cb.boundaries.iter().enumerate() {
+            assert!(
+                b > cb.centroids[i] && b < cb.centroids[i + 1],
+                "boundary {b} not between {} and {}",
+                cb.centroids[i],
+                cb.centroids[i + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn quantize_dequantize_roundtrip() {
+        let cb = generate_codebook(64, 3, 50).unwrap();
+        for &val in &[-0.5, -0.1, 0.0, 0.1, 0.5] {
+            let idx = cb.quantize(val);
+            let recon = cb.dequantize(idx);
+            assert!(
+                (val - recon).abs() < 0.5,
+                "val={val}, recon={recon}, idx={idx}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantize_extreme_values() {
+        let cb = generate_codebook(64, 4, 50).unwrap();
+        assert_eq!(cb.quantize(100.0) as usize, cb.centroids.len() - 1);
+        assert_eq!(cb.quantize(-100.0), 0);
+    }
+
+    #[test]
+    fn quantize_nan_returns_zero() {
+        let cb = generate_codebook(64, 2, 50).unwrap();
+        assert_eq!(cb.quantize(f32::NAN), 0);
+    }
+
+    #[test]
+    fn codebook_8bit() {
+        let cb = generate_codebook(128, 8, 50).unwrap();
+        assert_eq!(cb.centroids.len(), 256);
+        assert_eq!(cb.boundaries.len(), 255);
+    }
+
+    #[test]
+    fn codebook_large_dim_gaussian_path() {
+        let cb = generate_codebook(256, 4, 100).unwrap();
+        assert_eq!(cb.centroids.len(), 16);
+        for w in cb.centroids.windows(2) {
+            assert!(w[0] < w[1]);
+        }
+        for c in &cb.centroids {
+            assert!(c.abs() < 0.5, "centroid {c} too far from 0 for dim=256");
+        }
+    }
+
+    #[test]
+    fn invalid_bit_width() {
+        assert!(generate_codebook(64, 0, 50).is_err());
+        assert!(generate_codebook(64, 9, 50).is_err());
+    }
+
+    #[test]
+    fn invalid_dimension() {
+        assert!(generate_codebook(0, 4, 50).is_err());
+    }
+
+    #[test]
+    fn cache_returns_same_codebook() {
+        let mut cache = CodebookCache::new();
+        let c1 = cache.get_or_generate(64, 2).unwrap().centroids.clone();
+        let c2 = cache.get_or_generate(64, 2).unwrap().centroids.clone();
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn cache_different_configs() {
+        let mut cache = CodebookCache::new();
+        let len1 = cache.get_or_generate(64, 2).unwrap().centroids.len();
+        let len2 = cache.get_or_generate(64, 4).unwrap().centroids.len();
+        assert_ne!(len1, len2);
+    }
+
+    #[test]
+    fn cache_default() {
+        let mut cache = CodebookCache::default();
+        assert!(cache.get_or_generate(32, 2).is_ok());
+    }
+
+    #[test]
+    fn cache_propagates_errors() {
+        let mut cache = CodebookCache::new();
+        assert!(cache.get_or_generate(0, 2).is_err());
+        assert!(cache.get_or_generate(64, 0).is_err());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,10 @@ pub enum QjlError {
     StoreVersionMismatch { expected: u16, got: u16 },
     /// Outlier index out of range.
     OutlierIndexOutOfRange { index: u8, head_dim: usize },
+    /// Codebook bit width is invalid (must be 1..=8).
+    InvalidCodebookBitWidth(u8),
+    /// Dimension is invalid (must be > 0).
+    InvalidDimension(usize),
     /// I/O error from the underlying filesystem.
     Io(std::io::Error),
 }
@@ -53,6 +57,12 @@ impl fmt::Display for QjlError {
                     f,
                     "outlier index {index} out of range for head_dim {head_dim}"
                 )
+            }
+            Self::InvalidCodebookBitWidth(bits) => {
+                write!(f, "invalid codebook bit width: {bits} (must be 1..=8)")
+            }
+            Self::InvalidDimension(dim) => {
+                write!(f, "invalid dimension: {dim} (must be > 0)")
             }
             Self::Io(e) => write!(f, "I/O error: {e}"),
         }
@@ -115,6 +125,8 @@ mod tests {
                 index: 200,
                 head_dim: 128,
             },
+            QjlError::InvalidCodebookBitWidth(0),
+            QjlError::InvalidDimension(0),
             QjlError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "gone")),
         ];
         for v in &variants {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod codebook;
 pub mod error;
+pub mod math;
 pub mod outliers;
 pub mod quantize;
 pub mod quantizer;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,297 @@
+// Math helpers for Lloyd-Max codebook generation.
+//
+// Inspired by turboquant (MIT, https://github.com/abdelstark/turboquant).
+// All functions reimplemented from standard numerical methods:
+//   - Lanczos approximation for log-gamma
+//   - Beasley-Springer-Moro rational approximation for normal inverse CDF
+//   - Simpson's rule for numerical integration
+//   - Beta marginal PDF of unit-sphere coordinates
+
+use std::f64::consts::PI;
+
+/// Log-gamma via Lanczos approximation (g=7, n=9).
+pub(crate) fn lgamma(x: f64) -> f64 {
+    if x <= 0.0 {
+        return f64::INFINITY;
+    }
+    #[allow(clippy::excessive_precision)]
+    const C: [f64; 9] = [
+        0.99999999999980993,
+        676.5203681218851,
+        -1259.1392167224028,
+        771.32342877765313,
+        -176.61502916214059,
+        12.507343278686905,
+        -0.13857109526572012,
+        9.9843695780195716e-6,
+        1.5056327351493116e-7,
+    ];
+    const G: f64 = 7.0;
+
+    if x < 0.5 {
+        return PI.ln() - (PI * x).sin().ln() - lgamma(1.0 - x);
+    }
+    let x = x - 1.0;
+    let t = x + G + 0.5;
+    let mut a = C[0];
+    for (i, &ci) in C[1..].iter().enumerate() {
+        a += ci / (x + i as f64 + 1.0);
+    }
+    0.5 * (2.0 * PI).ln() + a.ln() + (x + 0.5) * t.ln() - t
+}
+
+/// PDF of the coordinate marginal distribution of a d-dimensional
+/// unit-sphere-uniform vector: f(x) ∝ (1 - x²)^((d-3)/2) for |x| < 1.
+///
+/// For d > 50, approximated by N(0, 1/d).
+pub(crate) fn beta_pdf(x: f64, dim: usize) -> f64 {
+    if dim < 2 {
+        return 0.0;
+    }
+    if dim > 50 {
+        let sigma2 = 1.0 / dim as f64;
+        let sigma = sigma2.sqrt();
+        return (-x * x / (2.0 * sigma2)).exp() / (sigma * (2.0 * PI).sqrt());
+    }
+    if x.abs() >= 1.0 {
+        return 0.0;
+    }
+    let exponent = (dim as f64 - 3.0) / 2.0;
+    let unnorm = (1.0 - x * x).powf(exponent);
+    let log_c = lgamma(dim as f64 / 2.0) - 0.5 * PI.ln() - lgamma((dim as f64 - 1.0) / 2.0);
+    log_c.exp() * unnorm
+}
+
+/// Normal inverse CDF (probit) via Beasley-Springer-Moro rational approximation.
+#[allow(clippy::excessive_precision)]
+pub(crate) fn normal_icdf(p: f64) -> f64 {
+    let a = [
+        -3.969683028665376e+01,
+        2.209460984245205e+02,
+        -2.759285104469687e+02,
+        1.383577518672690e+02,
+        -3.066479806614716e+01,
+        2.506628277459239e+00,
+    ];
+    let b = [
+        -5.447609879822406e+01,
+        1.615858368580409e+02,
+        -1.556989798598866e+02,
+        6.680131188771972e+01,
+        -1.328068155288572e+01,
+    ];
+    let c = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e+00,
+        -2.549732539343734e+00,
+        4.374664141464968e+00,
+        2.938163982698783e+00,
+    ];
+    let d = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e+00,
+        3.754408661907416e+00,
+    ];
+
+    let p_low = 0.02425;
+    let p_high = 1.0 - p_low;
+
+    if p < p_low {
+        let q = (-2.0 * p.ln()).sqrt();
+        (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5])
+            / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0)
+    } else if p <= p_high {
+        let q = p - 0.5;
+        let r = q * q;
+        (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q
+            / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0)
+    } else {
+        let q = (-2.0 * (1.0 - p).ln()).sqrt();
+        -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5])
+            / ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0)
+    }
+}
+
+/// Sample from the coordinate marginal of a d-dim unit-sphere vector
+/// at the given quantile via inverse CDF.
+pub(crate) fn sample_beta_marginal(dim: usize, u: f64) -> f64 {
+    if dim > 50 {
+        let sigma = (1.0 / dim as f64).sqrt();
+        return sigma * normal_icdf(u);
+    }
+    numerical_icdf(u, dim)
+}
+
+/// Bisection-based inverse CDF for the beta marginal.
+fn numerical_icdf(u: f64, dim: usize) -> f64 {
+    let mut lo = -1.0_f64;
+    let mut hi = 1.0_f64;
+    for _ in 0..64 {
+        let mid = (lo + hi) / 2.0;
+        if numerical_cdf(mid, dim) < u {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    (lo + hi) / 2.0
+}
+
+/// Numerical CDF of beta_pdf from -1 to x via Simpson's rule.
+fn numerical_cdf(x: f64, dim: usize) -> f64 {
+    let n = 200usize;
+    let a = -0.9999_f64;
+    let b = x.min(0.9999);
+    if b <= a {
+        return 0.0;
+    }
+    let h = (b - a) / n as f64;
+    let mut sum = beta_pdf(a, dim) + beta_pdf(b, dim);
+    for i in 1..n {
+        let xi = a + i as f64 * h;
+        let w = if i % 2 == 0 { 2.0 } else { 4.0 };
+        sum += w * beta_pdf(xi, dim);
+    }
+    sum * h / 3.0
+}
+
+/// Simpson's rule returning paired integrals (∫f, ∫g) simultaneously.
+pub(crate) fn simpson_integrate<F>(a: f64, b: f64, n: usize, f: F) -> (f64, f64)
+where
+    F: Fn(f64) -> (f64, f64),
+{
+    let n = if n.is_multiple_of(2) { n } else { n + 1 };
+    let h = (b - a) / n as f64;
+    let (f0, g0) = f(a);
+    let (fn_, gn) = f(b);
+    let mut sum_f = f0 + fn_;
+    let mut sum_g = g0 + gn;
+    for i in 1..n {
+        let x = a + i as f64 * h;
+        let (fi, gi) = f(x);
+        let w = if i % 2 == 0 { 2.0 } else { 4.0 };
+        sum_f += w * fi;
+        sum_g += w * gi;
+    }
+    (sum_f * h / 3.0, sum_g * h / 3.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lgamma_known_values() {
+        // Γ(1) = 1 → lgamma(1) = 0
+        assert!((lgamma(1.0)).abs() < 1e-10);
+        // Γ(2) = 1 → lgamma(2) = 0
+        assert!((lgamma(2.0)).abs() < 1e-10);
+        // Γ(5) = 24 → lgamma(5) = ln(24)
+        assert!((lgamma(5.0) - 24.0_f64.ln()).abs() < 1e-8);
+        // Γ(0.5) = √π → lgamma(0.5) = ln(√π)
+        assert!((lgamma(0.5) - 0.5 * PI.ln()).abs() < 1e-8);
+    }
+
+    #[test]
+    fn lgamma_negative_returns_inf() {
+        assert!(lgamma(0.0).is_infinite());
+        assert!(lgamma(-1.0).is_infinite());
+    }
+
+    #[test]
+    fn beta_pdf_integrates_to_one() {
+        for dim in [5, 10, 20] {
+            let n = 1000;
+            let h = 2.0 / n as f64;
+            let sum: f64 = (0..n)
+                .map(|i| beta_pdf(-1.0 + (i as f64 + 0.5) * h, dim) * h)
+                .sum();
+            assert!((sum - 1.0).abs() < 0.05, "dim={dim}: integral={sum}");
+        }
+    }
+
+    #[test]
+    fn beta_pdf_symmetric() {
+        for dim in [5, 10, 100] {
+            for &x in &[0.1, 0.3, 0.5] {
+                let diff = (beta_pdf(x, dim) - beta_pdf(-x, dim)).abs();
+                assert!(diff < 1e-10, "dim={dim}, x={x}: diff={diff}");
+            }
+        }
+    }
+
+    #[test]
+    fn beta_pdf_dim_below_2_is_zero() {
+        assert_eq!(beta_pdf(0.5, 0), 0.0);
+        assert_eq!(beta_pdf(0.5, 1), 0.0);
+    }
+
+    #[test]
+    fn beta_pdf_at_boundary_is_zero() {
+        assert_eq!(beta_pdf(1.0, 10), 0.0);
+        assert_eq!(beta_pdf(-1.0, 10), 0.0);
+    }
+
+    #[test]
+    fn beta_pdf_large_dim_gaussian_path() {
+        let dim = 100;
+        let pdf = beta_pdf(0.0, dim);
+        let expected = (dim as f64 / (2.0 * PI)).sqrt();
+        assert!(
+            (pdf - expected).abs() / expected < 0.1,
+            "pdf={pdf}, expected={expected}"
+        );
+    }
+
+    #[test]
+    fn normal_icdf_median_is_zero() {
+        assert!(normal_icdf(0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn normal_icdf_one_sigma() {
+        assert!((normal_icdf(0.8413) - 1.0).abs() < 0.01);
+        assert!((normal_icdf(0.1587) + 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn normal_icdf_symmetric_tails() {
+        let lo = normal_icdf(0.001);
+        let hi = normal_icdf(0.999);
+        assert!((lo + hi).abs() < 0.01);
+    }
+
+    #[test]
+    fn sample_beta_marginal_large_dim() {
+        let dim = 128;
+        assert!(sample_beta_marginal(dim, 0.5).abs() < 0.01);
+        let lo = sample_beta_marginal(dim, 0.01);
+        let hi = sample_beta_marginal(dim, 0.99);
+        assert!(lo < 0.0);
+        assert!(hi > 0.0);
+        assert!((lo + hi).abs() < 0.01);
+    }
+
+    #[test]
+    fn sample_beta_marginal_small_dim() {
+        let dim = 10;
+        assert!(sample_beta_marginal(dim, 0.5).abs() < 0.1);
+        assert!(sample_beta_marginal(dim, 0.05) < sample_beta_marginal(dim, 0.95));
+    }
+
+    #[test]
+    fn simpson_integrate_constant() {
+        let (f_int, g_int) = simpson_integrate(0.0, 1.0, 100, |_| (1.0, 2.0));
+        assert!((f_int - 1.0).abs() < 1e-10);
+        assert!((g_int - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn simpson_integrate_x_squared() {
+        // ∫₀¹ x² dx = 1/3
+        let (val, _) = simpson_integrate(0.0, 1.0, 100, |x| (x * x, 0.0));
+        assert!((val - 1.0 / 3.0).abs() < 1e-8);
+    }
+}

--- a/src/outliers.rs
+++ b/src/outliers.rs
@@ -47,7 +47,7 @@ pub fn detect_outliers(
     Ok(indices)
 }
 
-/// Build an outlier mask from indices. mask[i] = true if i is an outlier.
+/// Build an outlier mask from indices. mask\[i\] = true if i is an outlier.
 pub fn outlier_mask(indices: &[u8], head_dim: usize) -> Vec<bool> {
     let mut mask = vec![false; head_dim];
     for &idx in indices {

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -5,15 +5,15 @@ use crate::sketch::{l2_norm, QJLSketch};
 /// Compressed key vectors — packed sign bits with outlier separation.
 #[derive(Clone, Debug)]
 pub struct CompressedKeys {
-    /// Packed sign bits for inlier dimensions [num_vectors, sketch_dim/8].
+    /// Packed sign bits for inlier dimensions \[num_vectors, sketch_dim/8\].
     pub key_quant: Vec<u8>,
-    /// Packed sign bits for outlier dimensions [num_vectors, outlier_sketch_dim/8].
+    /// Packed sign bits for outlier dimensions \[num_vectors, outlier_sketch_dim/8\].
     pub key_outlier_quant: Vec<u8>,
-    /// L2 norm of each full vector [num_vectors].
+    /// L2 norm of each full vector \[num_vectors\].
     pub key_norms: Vec<f32>,
-    /// L2 norm of outlier components [num_vectors].
+    /// L2 norm of outlier components \[num_vectors\].
     pub outlier_norms: Vec<f32>,
-    /// Outlier dimension indices for this group [outlier_count].
+    /// Outlier dimension indices for this group \[outlier_count\].
     pub outlier_indices: Vec<u8>,
     /// Number of vectors.
     pub num_vectors: usize,

--- a/src/score.rs
+++ b/src/score.rs
@@ -7,12 +7,12 @@ impl QJLSketch {
     ///
     /// Matches the QJL CUDA kernel (`calc_score_kernel`):
     ///   q_sketch = query @ proj_dir_score  (full sketch)
-    ///   q_outlier_sketch[i] = Σ_j query[outlier_j] * proj_dir_score[outlier_j, i]
+    ///   q_outlier_sketch\[i\] = Σ_j query\[outlier_j\] * proj_dir_score\[outlier_j, i\]
     ///   q_inlier_sketch = q_sketch - q_outlier_sketch
-    ///   score = sqrt(π/2)/s * ||k_inlier|| * Σ sign(k_inlier_i) * q_inlier_sketch[i]
-    ///         + sqrt(π/2)/os * ||k_outlier|| * Σ sign(k_outlier_i) * q_outlier_sketch[i]
+    ///   score = sqrt(π/2)/s * ||k_inlier|| * Σ sign(k_inlier_i) * q_inlier_sketch\[i\]
+    ///         + sqrt(π/2)/os * ||k_outlier|| * Σ sign(k_outlier_i) * q_outlier_sketch\[i\]
     ///
-    /// - `query`: [head_dim] f32
+    /// - `query`: \[head_dim\] f32
     /// - `compressed`: compressed key vectors from `quantize()`
     pub fn score(&self, query: &[f32], compressed: &CompressedKeys) -> Result<Vec<f32>> {
         let d = self.head_dim;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -123,7 +123,7 @@ fn transpose(data: &[f32], rows: usize, cols: usize) -> Vec<f32> {
 }
 
 /// Compute the matrix-vector product: result = mat @ vec.
-/// mat is [rows, cols] row-major, vec is [cols].
+/// mat is \[rows, cols\] row-major, vec is \[cols\].
 #[allow(clippy::needless_range_loop)]
 pub fn matvec(mat: &[f32], rows: usize, cols: usize, vec: &[f32]) -> Vec<f32> {
     assert_eq!(mat.len(), rows * cols);

--- a/src/values.rs
+++ b/src/values.rs
@@ -5,9 +5,9 @@ use crate::error::{validate_finite, QjlError, Result};
 pub struct CompressedValues {
     /// Bit-packed quantized values. Layout depends on bits.
     pub packed: Vec<i32>,
-    /// Per-group scale factors [num_groups].
+    /// Per-group scale factors \[num_groups\].
     pub scale: Vec<f32>,
-    /// Per-group minimums [num_groups].
+    /// Per-group minimums \[num_groups\].
     pub mn: Vec<f32>,
     /// Number of elements before packing.
     pub num_elements: usize,
@@ -20,7 +20,7 @@ pub struct CompressedValues {
 /// Quantize a 1-D slice of f32 values with min-max scalar quantization
 /// and pack into i32 words.
 ///
-/// - `values`: input values [num_elements]
+/// - `values`: input values \[num_elements\]
 /// - `group_size`: number of elements per quantization group
 /// - `bits`: quantization bit-width (2 or 4)
 pub fn quantize_values(values: &[f32], group_size: usize, bits: u8) -> Result<CompressedValues> {
@@ -111,8 +111,8 @@ pub fn dequantize_all(compressed: &CompressedValues) -> Vec<f32> {
 
 /// Fused dequantize + weighted sum: result = weights @ dequantized_values.
 ///
-/// - `weights`: [num_elements] f32 — attention weights
-/// - `compressed`: quantized values [num_elements]
+/// - `weights`: \[num_elements\] f32 — attention weights
+/// - `compressed`: quantized values \[num_elements\]
 ///
 /// Returns the weighted sum (scalar).
 pub fn quantized_dot(weights: &[f32], compressed: &CompressedValues) -> Result<f32> {


### PR DESCRIPTION
## Summary

Add Lloyd-Max optimal scalar quantization codebook for the Beta(1/2, (d-1)/2) coordinate marginal of unit-sphere-uniform vectors.

## New modules

- **`src/math.rs`** — numerical helpers (lgamma, beta_pdf, normal_icdf, sample_beta_marginal, simpson_integrate)
- **`src/codebook.rs`** — Codebook struct, generate_codebook, quantize/dequantize, CodebookCache

## Also included

- Error variants: `InvalidCodebookBitWidth`, `InvalidDimension`
- `THIRD_PARTY_NOTICES` (TurboQuant MIT attribution)
- Fix 15 pre-existing rustdoc warnings
- Algorithm 7 documented in `docs/design/algorithms.md`
- Version bump 0.2.0 → 0.3.0

## Validation

- 122 tests pass (95 unit + 18 persistence + 9 quality)
- `cargo fmt`, `cargo clippy -D warnings`, `cargo doc --no-deps`: all clean