### PR TITLE
feat: add MSE-optimal quantization (rotate + Lloyd-Max per-coordinate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `rotation` module — `RandomRotation` d×d orthogonal matrix via
+  Gaussian QR with sign correction (Haar-uniform construction)
+- `mse_quant` module — MSE-optimal vector quantization (TurboQuant Stage 1)
+  - `mse_quantize` — rotate + Lloyd-Max per-coordinate quantization
+  - `mse_dequantize` — centroid lookup + inverse rotation
+  - `mse_score` — score query against quantized vectors (rotate query
+    once, dot with dequantized rotated coordinates)
+  - `MseQuantized` struct
+- 14 new tests (7 rotation + 6 mse_quant + 1 quality)
+
 ## [0.3.0] — 2025-07-24
 
 ### Added

--- a/docs/design/algorithms/10-mse-quantization.md
+++ b/docs/design/algorithms/10-mse-quantization.md
@@ -1,0 +1,91 @@
+# Algorithm 10: MSE-Optimal Quantization
+
+Source: TurboQuant paper (Stage 1), arXiv:2504.19874.
+Impl: `src/rotation.rs` → `RandomRotation`, `src/mse_quant.rs` →
+`mse_quantize`, `mse_dequantize`, `mse_score`.
+
+Achieves the optimal rate-distortion trade-off for MSE by combining
+a random orthogonal rotation (decorrelation) with Lloyd-Max scalar
+quantization per coordinate.
+
+## Random Rotation
+
+```
+Input:
+  dim  = vector dimension
+  seed = RNG seed
+
+Output:
+  Π : d×d orthogonal matrix (proper rotation, det = +1)
+
+Algorithm:
+  1. Sample d×d Gaussian matrix G
+  2. QR decompose: G = QR
+  3. Sign-correct: flip columns of Q where R diagonal < 0
+  4. Π = Q · diag(signs)
+```
+
+After rotation, coordinates of a unit-sphere vector are approximately
+i.i.d. Beta(1/2, (d-1)/2), making per-coordinate quantization optimal.
+
+## Quantize
+
+```
+Input:
+  vectors  : [num_vectors, d] f32
+  rotation : RandomRotation (d×d)
+  codebook : Codebook (from Algorithm 7)
+
+Output:
+  indices : [num_vectors × d] u8  — codebook index per coordinate
+
+Algorithm:
+  For each vector x:
+    1. y = Π · x                    (rotate)
+    2. For each j: idx_j = codebook.quantize(y_j)  (scalar quantize)
+```
+
+## Dequantize
+
+```
+Input:
+  indices  : [num_vectors × d] u8
+  rotation : RandomRotation
+  codebook : Codebook
+
+Output:
+  vectors : [num_vectors, d] f32
+
+Algorithm:
+  For each quantized vector:
+    1. ỹ_j = codebook.dequantize(idx_j)   (centroid lookup)
+    2. x̃ = Πᵀ · ỹ                         (inverse rotate)
+```
+
+## Score
+
+```
+Input:
+  query     : [d] f32
+  quantized : MseQuantized
+  rotation  : RandomRotation
+  codebook  : Codebook
+
+Output:
+  scores : [num_vectors] f32
+
+Algorithm:
+  1. q_rot = Π · query                    (rotate query once)
+  2. For each quantized vector v:
+       score = Σ_j q_rot[j] · codebook.dequantize(indices[v,j])
+```
+
+The scoring avoids inverse rotation of every stored vector.
+By orthogonality: dot(q, Πᵀ·ỹ) = dot(Π·q, ỹ). The query is
+rotated once (O(d²)), then each score is O(d) centroid lookups + dot.
+
+## Theoretical MSE bound
+
+Δ_MSE(b) = √3 · π/2 · (1/4)^b
+
+For b=4: ≈ 0.011 per dimension. MSE decreases exponentially with bits.

--- a/docs/design/algorithms/README.md
+++ b/docs/design/algorithms/README.md
@@ -14,7 +14,9 @@ src/
 ├── values.rs       CompressedValues — min-max quantization, fused matmul
 ├── quantizer.rs    KeyQuantizer — batch + streaming wrapper
 ├── math.rs         Numerical helpers — lgamma, beta_pdf, normal_icdf, Simpson's rule
-└── codebook.rs     Codebook — Lloyd-Max optimal scalar quantization
+├── codebook.rs     Codebook — Lloyd-Max optimal scalar quantization
+├── rotation.rs     RandomRotation — d×d orthogonal decorrelation
+└── mse_quant.rs    MSE-optimal quantization — rotate + Lloyd-Max
 ```
 
 ## Algorithm index
@@ -30,6 +32,7 @@ src/
 | 7 | [Lloyd-Max Codebook](07-lloyd-max-codebook.md) | `codebook.rs`, `math.rs` | Optimal scalar quantization for sphere marginals |
 | 8 | [Compressed Scoring](08-compressed-scoring.md) | `score.rs` | Hamming-based cosine estimator |
 | 9 | [Streaming Quantizer](09-streaming-quantizer.md) | `quantizer.rs` | Batch + one-at-a-time compression |
+| 10 | [MSE Quantization](10-mse-quantization.md) | `rotation.rs`, `mse_quant.rs` | Rotate + Lloyd-Max per-coordinate |
 
 ## Cross-cutting
 

--- a/docs/design/algorithms/data-structures.md
+++ b/docs/design/algorithms/data-structures.md
@@ -28,6 +28,21 @@ pub struct Codebook {
     pub bit_width: u8,                // 1..=8
 }
 
+// src/rotation.rs
+pub struct RandomRotation {
+    matrix: Vec<f32>,                 // d×d row-major orthogonal matrix
+    matrix_t: Vec<f32>,               // d×d transposed (cached)
+    pub dim: usize,
+}
+
+// src/mse_quant.rs
+pub struct MseQuantized {
+    pub indices: Vec<u8>,             // [num_vectors × dim] codebook indices
+    pub num_vectors: usize,
+    pub dim: usize,
+    pub bit_width: u8,
+}
+
 // src/values.rs
 pub struct CompressedValues {
     pub packed: Vec<i32>,             // bit-packed quantized values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod codebook;
 pub mod error;
 pub mod math;
+pub mod mse_quant;
 pub mod outliers;
 pub mod quantize;
 pub mod quantizer;
+pub mod rotation;
 pub mod score;
 pub mod sketch;
 pub mod store;

--- a/src/mse_quant.rs
+++ b/src/mse_quant.rs
@@ -1,0 +1,279 @@
+// MSE-optimal vector quantization: rotate → Lloyd-Max per-coordinate.
+//
+// This is Stage 1 of TurboQuant. The random rotation decorrelates
+// coordinates so that per-coordinate scalar quantization achieves
+// the optimal rate-distortion trade-off for MSE.
+
+use crate::codebook::Codebook;
+use crate::error::{validate_finite, QjlError, Result};
+use crate::rotation::RandomRotation;
+
+/// MSE-quantized vectors: per-coordinate codebook indices after rotation.
+#[derive(Debug, Clone)]
+pub struct MseQuantized {
+    /// Codebook indices, flattened \[num_vectors × dim\].
+    pub indices: Vec<u8>,
+    /// Number of vectors.
+    pub num_vectors: usize,
+    /// Vector dimension.
+    pub dim: usize,
+    /// Bits per coordinate.
+    pub bit_width: u8,
+}
+
+/// Quantize vectors via rotation + Lloyd-Max scalar quantization.
+///
+/// For each vector: rotate → quantize each coordinate via codebook.
+///
+/// - `vectors`: flattened \[num_vectors, dim\] row-major
+pub fn mse_quantize(
+    vectors: &[f32],
+    num_vectors: usize,
+    rotation: &RandomRotation,
+    codebook: &Codebook,
+) -> Result<MseQuantized> {
+    let dim = rotation.dim;
+    if vectors.len() != num_vectors * dim {
+        return Err(QjlError::DimensionMismatch {
+            expected: num_vectors * dim,
+            got: vectors.len(),
+        });
+    }
+    validate_finite(vectors, "mse_quantize input")?;
+
+    let mut indices = Vec::with_capacity(num_vectors * dim);
+
+    for v in 0..num_vectors {
+        let x = &vectors[v * dim..(v + 1) * dim];
+        let y = rotation.rotate(x)?;
+        for &val in &y {
+            indices.push(codebook.quantize(val));
+        }
+    }
+
+    Ok(MseQuantized {
+        indices,
+        num_vectors,
+        dim,
+        bit_width: codebook.bit_width,
+    })
+}
+
+/// Reconstruct vectors from MSE-quantized representation.
+///
+/// For each vector: dequantize each coordinate → inverse rotate.
+pub fn mse_dequantize(
+    quantized: &MseQuantized,
+    rotation: &RandomRotation,
+    codebook: &Codebook,
+) -> Result<Vec<f32>> {
+    if rotation.dim != quantized.dim {
+        return Err(QjlError::DimensionMismatch {
+            expected: quantized.dim,
+            got: rotation.dim,
+        });
+    }
+
+    let dim = quantized.dim;
+    let mut out = Vec::with_capacity(quantized.num_vectors * dim);
+
+    for v in 0..quantized.num_vectors {
+        let idx_slice = &quantized.indices[v * dim..(v + 1) * dim];
+        let y_approx: Vec<f32> = idx_slice.iter().map(|&i| codebook.dequantize(i)).collect();
+        let x_approx = rotation.rotate_inverse(&y_approx)?;
+        out.extend_from_slice(&x_approx);
+    }
+
+    Ok(out)
+}
+
+/// Score a query against MSE-quantized vectors.
+///
+/// Rotates the query once, then dots with dequantized rotated
+/// coordinates directly: dot(Π·q, ỹ) = dot(q, Πᵀ·ỹ) by orthogonality.
+pub fn mse_score(
+    query: &[f32],
+    quantized: &MseQuantized,
+    rotation: &RandomRotation,
+    codebook: &Codebook,
+) -> Result<Vec<f32>> {
+    let dim = rotation.dim;
+    if query.len() != dim {
+        return Err(QjlError::DimensionMismatch {
+            expected: dim,
+            got: query.len(),
+        });
+    }
+    if quantized.dim != dim {
+        return Err(QjlError::DimensionMismatch {
+            expected: dim,
+            got: quantized.dim,
+        });
+    }
+    validate_finite(query, "mse_score query")?;
+
+    let q_rot = rotation.rotate(query)?;
+
+    let scores = (0..quantized.num_vectors)
+        .map(|v| {
+            let idx_slice = &quantized.indices[v * dim..(v + 1) * dim];
+            q_rot
+                .iter()
+                .zip(idx_slice.iter())
+                .map(|(&q, &i)| q * codebook.dequantize(i))
+                .sum()
+        })
+        .collect();
+
+    Ok(scores)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codebook::generate_codebook;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+    use rand_distr::{Distribution, StandardNormal};
+
+    fn random_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+        let normal: StandardNormal = StandardNormal;
+        (0..d)
+            .map(|_| {
+                let v: f64 = normal.sample(rng);
+                v as f32
+            })
+            .collect()
+    }
+
+    fn normalize(v: &mut [f32]) {
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            v.iter_mut().for_each(|x| *x /= norm);
+        }
+    }
+
+    #[test]
+    fn roundtrip_reconstruction() {
+        let dim = 64;
+        let rot = RandomRotation::new(dim, 42).unwrap();
+        let cb = generate_codebook(dim, 4, 100).unwrap();
+        let mut rng = ChaCha20Rng::seed_from_u64(100);
+
+        let mut v = random_vec(dim, &mut rng);
+        normalize(&mut v);
+
+        let q = mse_quantize(&v, 1, &rot, &cb).unwrap();
+        let recon = mse_dequantize(&q, &rot, &cb).unwrap();
+
+        // MSE should be small for 4-bit quantization of a unit vector
+        let mse: f32 = v
+            .iter()
+            .zip(recon.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / dim as f32;
+        assert!(mse < 0.1, "MSE too high: {mse}");
+    }
+
+    #[test]
+    fn score_vs_exact() {
+        let dim = 64;
+        let rot = RandomRotation::new(dim, 42).unwrap();
+        let cb = generate_codebook(dim, 4, 100).unwrap();
+        let mut rng = ChaCha20Rng::seed_from_u64(200);
+
+        let mut q_vec = random_vec(dim, &mut rng);
+        normalize(&mut q_vec);
+        let mut k_vec = random_vec(dim, &mut rng);
+        normalize(&mut k_vec);
+
+        let exact: f32 = q_vec.iter().zip(k_vec.iter()).map(|(a, b)| a * b).sum();
+
+        let quantized = mse_quantize(&k_vec, 1, &rot, &cb).unwrap();
+        let scores = mse_score(&q_vec, &quantized, &rot, &cb).unwrap();
+
+        let error = (scores[0] - exact).abs();
+        assert!(
+            error < 0.3,
+            "score error too high: approx={}, exact={exact}, error={error}",
+            scores[0]
+        );
+    }
+
+    #[test]
+    fn mse_decreases_with_bits() {
+        let dim = 128;
+        let rot = RandomRotation::new(dim, 42).unwrap();
+        let cb2 = generate_codebook(dim, 2, 100).unwrap();
+        let cb4 = generate_codebook(dim, 4, 100).unwrap();
+        let mut rng = ChaCha20Rng::seed_from_u64(300);
+
+        let mut v = random_vec(dim, &mut rng);
+        normalize(&mut v);
+
+        let q2 = mse_quantize(&v, 1, &rot, &cb2).unwrap();
+        let r2 = mse_dequantize(&q2, &rot, &cb2).unwrap();
+        let mse2: f32 = v
+            .iter()
+            .zip(r2.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / dim as f32;
+
+        let q4 = mse_quantize(&v, 1, &rot, &cb4).unwrap();
+        let r4 = mse_dequantize(&q4, &rot, &cb4).unwrap();
+        let mse4: f32 = v
+            .iter()
+            .zip(r4.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / dim as f32;
+
+        assert!(
+            mse4 < mse2,
+            "4-bit MSE ({mse4}) should be less than 2-bit MSE ({mse2})"
+        );
+    }
+
+    #[test]
+    fn dimension_mismatch_quantize() {
+        let rot = RandomRotation::new(16, 1).unwrap();
+        let cb = generate_codebook(16, 2, 50).unwrap();
+        assert!(mse_quantize(&[1.0; 10], 1, &rot, &cb).is_err());
+    }
+
+    #[test]
+    fn dimension_mismatch_score() {
+        let rot = RandomRotation::new(16, 1).unwrap();
+        let cb = generate_codebook(16, 2, 50).unwrap();
+        let v = vec![0.1f32; 16];
+        let q = mse_quantize(&v, 1, &rot, &cb).unwrap();
+        assert!(mse_score(&[1.0; 8], &q, &rot, &cb).is_err());
+    }
+
+    #[test]
+    fn multiple_vectors() {
+        let dim = 32;
+        let rot = RandomRotation::new(dim, 42).unwrap();
+        let cb = generate_codebook(dim, 3, 50).unwrap();
+        let mut rng = ChaCha20Rng::seed_from_u64(400);
+
+        let num = 5;
+        let vecs: Vec<f32> = (0..num).flat_map(|_| random_vec(dim, &mut rng)).collect();
+        let query = random_vec(dim, &mut rng);
+
+        let q = mse_quantize(&vecs, num, &rot, &cb).unwrap();
+        assert_eq!(q.indices.len(), num * dim);
+        assert_eq!(q.num_vectors, num);
+
+        let scores = mse_score(&query, &q, &rot, &cb).unwrap();
+        assert_eq!(scores.len(), num);
+        for s in &scores {
+            assert!(s.is_finite());
+        }
+
+        let recon = mse_dequantize(&q, &rot, &cb).unwrap();
+        assert_eq!(recon.len(), num * dim);
+    }
+}

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -1,0 +1,190 @@
+// Random orthogonal rotation for TurboQuant decorrelation.
+//
+// Generates a d×d orthogonal matrix via QR decomposition of a
+// random Gaussian matrix, with sign correction to ensure a proper
+// rotation (det = +1). This is the standard Haar-uniform random
+// orthogonal matrix construction.
+
+use nalgebra::{DMatrix, DVector};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+
+use crate::error::{validate_finite, QjlError, Result};
+
+/// A d×d random orthogonal rotation matrix.
+///
+/// Used as the decorrelation step before Lloyd-Max scalar quantization.
+/// After rotation, coordinates of a unit-sphere vector are approximately
+/// i.i.d. Beta(1/2, (d-1)/2), making per-coordinate quantization optimal.
+pub struct RandomRotation {
+    /// d×d orthogonal matrix, row-major.
+    matrix: Vec<f32>,
+    /// d×d transposed matrix (cached for inverse rotation).
+    matrix_t: Vec<f32>,
+    /// Vector dimension.
+    pub dim: usize,
+}
+
+impl RandomRotation {
+    /// Create a random orthogonal rotation for dimension `dim`.
+    ///
+    /// Algorithm:
+    /// 1. Sample d×d Gaussian matrix
+    /// 2. QR decompose → Q is orthogonal
+    /// 3. Correct column signs so R diagonal is positive (ensures proper rotation)
+    pub fn new(dim: usize, seed: u64) -> Result<Self> {
+        if dim == 0 {
+            return Err(QjlError::InvalidDimension(dim));
+        }
+
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
+        let normal = StandardNormal;
+
+        let data: Vec<f64> = (0..dim * dim).map(|_| normal.sample(&mut rng)).collect();
+        let g = DMatrix::from_vec(dim, dim, data);
+
+        let qr = g.qr();
+        let q = qr.q();
+        let r = qr.r();
+
+        // Sign correction: flip columns where R diagonal is negative
+        let signs: Vec<f64> = (0..dim)
+            .map(|i| if r[(i, i)] < 0.0 { -1.0 } else { 1.0 })
+            .collect();
+        let sign_diag = DMatrix::from_diagonal(&DVector::from_vec(signs));
+        let mat = q * sign_diag;
+
+        // Convert to f32 row-major
+        let mut matrix = vec![0.0f32; dim * dim];
+        let mut matrix_t = vec![0.0f32; dim * dim];
+        for r in 0..dim {
+            for c in 0..dim {
+                let v = mat[(r, c)] as f32;
+                matrix[r * dim + c] = v;
+                matrix_t[c * dim + r] = v;
+            }
+        }
+
+        Ok(Self {
+            matrix,
+            matrix_t,
+            dim,
+        })
+    }
+
+    /// Apply rotation: y = Π·x
+    pub fn rotate(&self, x: &[f32]) -> Result<Vec<f32>> {
+        if x.len() != self.dim {
+            return Err(QjlError::DimensionMismatch {
+                expected: self.dim,
+                got: x.len(),
+            });
+        }
+        validate_finite(x, "rotation input")?;
+        Ok(matvec_square(&self.matrix, self.dim, x))
+    }
+
+    /// Apply inverse rotation: x = Πᵀ·y
+    pub fn rotate_inverse(&self, y: &[f32]) -> Result<Vec<f32>> {
+        if y.len() != self.dim {
+            return Err(QjlError::DimensionMismatch {
+                expected: self.dim,
+                got: y.len(),
+            });
+        }
+        validate_finite(y, "inverse rotation input")?;
+        Ok(matvec_square(&self.matrix_t, self.dim, y))
+    }
+}
+
+/// Matrix-vector product for a d×d row-major matrix.
+fn matvec_square(mat: &[f32], dim: usize, x: &[f32]) -> Vec<f32> {
+    let mut out = vec![0.0f32; dim];
+    for r in 0..dim {
+        let row = &mat[r * dim..(r + 1) * dim];
+        let mut acc = 0.0f32;
+        for (a, b) in row.iter().zip(x.iter()) {
+            acc += a * b;
+        }
+        out[r] = acc;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orthogonality() {
+        let dim = 16;
+        let rot = RandomRotation::new(dim, 42).unwrap();
+        // Π·Πᵀ ≈ I
+        for i in 0..dim {
+            for j in 0..dim {
+                let mut dot = 0.0f32;
+                for k in 0..dim {
+                    dot += rot.matrix[i * dim + k] * rot.matrix[j * dim + k];
+                }
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (dot - expected).abs() < 1e-5,
+                    "[{i},{j}]: expected {expected}, got {dot}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip() {
+        let dim = 32;
+        let rot = RandomRotation::new(dim, 123).unwrap();
+        let x: Vec<f32> = (0..dim).map(|i| i as f32 / dim as f32).collect();
+        let y = rot.rotate(&x).unwrap();
+        let x2 = rot.rotate_inverse(&y).unwrap();
+        for (a, b) in x.iter().zip(x2.iter()) {
+            assert!((a - b).abs() < 1e-4, "roundtrip failed: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn preserves_norm() {
+        let dim = 64;
+        let rot = RandomRotation::new(dim, 7).unwrap();
+        let x: Vec<f32> = (0..dim).map(|i| (i as f32).sin()).collect();
+        let norm_x: f32 = x.iter().map(|v| v * v).sum::<f32>().sqrt();
+        let y = rot.rotate(&x).unwrap();
+        let norm_y: f32 = y.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!(
+            (norm_x - norm_y).abs() < 1e-3,
+            "norm not preserved: {norm_x} vs {norm_y}"
+        );
+    }
+
+    #[test]
+    fn deterministic() {
+        let a = RandomRotation::new(16, 42).unwrap();
+        let b = RandomRotation::new(16, 42).unwrap();
+        assert_eq!(a.matrix, b.matrix);
+    }
+
+    #[test]
+    fn different_seeds() {
+        let a = RandomRotation::new(16, 42).unwrap();
+        let b = RandomRotation::new(16, 99).unwrap();
+        assert_ne!(a.matrix, b.matrix);
+    }
+
+    #[test]
+    fn dimension_mismatch() {
+        let rot = RandomRotation::new(4, 1).unwrap();
+        assert!(rot.rotate(&[1.0, 2.0]).is_err());
+        assert!(rot.rotate_inverse(&[1.0, 2.0]).is_err());
+    }
+
+    #[test]
+    fn invalid_dimension_zero() {
+        assert!(RandomRotation::new(0, 1).is_err());
+    }
+}

--- a/tests/quality/main.rs
+++ b/tests/quality/main.rs
@@ -1,6 +1,7 @@
 mod helpers;
 mod test_compressed_ranking;
 mod test_distortion;
+mod test_mse_quant;
 mod test_outlier_benefit;
 mod test_ranking;
 mod test_rotation;

--- a/tests/quality/test_mse_quant.rs
+++ b/tests/quality/test_mse_quant.rs
@@ -1,0 +1,54 @@
+use super::helpers::*;
+use qjl_sketch::codebook::generate_codebook;
+use qjl_sketch::mse_quant::{mse_quantize, mse_score};
+use qjl_sketch::rotation::RandomRotation;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+fn normalize(v: &mut [f32]) {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        v.iter_mut().for_each(|x| *x /= norm);
+    }
+}
+
+#[test]
+fn test_mse_ranking_preservation() {
+    let dim = 64;
+    let num_keys = 100;
+    let num_trials = 50;
+    let rot = RandomRotation::new(dim, 42).unwrap();
+    let cb = generate_codebook(dim, 4, 100).unwrap();
+
+    let mut tau_sum = 0.0f32;
+
+    for trial in 0..num_trials {
+        let mut rng = ChaCha20Rng::seed_from_u64(800 + trial);
+        let mut q = random_vec(dim, &mut rng);
+        normalize(&mut q);
+
+        let mut keys = Vec::with_capacity(num_keys * dim);
+        for _ in 0..num_keys {
+            let mut k = random_vec(dim, &mut rng);
+            normalize(&mut k);
+            keys.extend_from_slice(&k);
+        }
+
+        let exact_scores: Vec<f32> = (0..num_keys)
+            .map(|i| dot(&q, &keys[i * dim..(i + 1) * dim]))
+            .collect();
+        let exact_ranking = argsort_desc(&exact_scores);
+
+        let quantized = mse_quantize(&keys, num_keys, &rot, &cb).unwrap();
+        let approx_scores = mse_score(&q, &quantized, &rot, &cb).unwrap();
+        let approx_ranking = argsort_desc(&approx_scores);
+
+        tau_sum += kendall_tau(&exact_ranking, &approx_ranking);
+    }
+
+    let mean_tau = tau_sum / num_trials as f32;
+    assert!(
+        mean_tau > 0.60,
+        "mean Kendall's tau {mean_tau:.3} <= 0.60 over {num_trials} trials"
+    );
+}


### PR DESCRIPTION
## Summary

Add TurboQuant Stage 1: MSE-optimal vector quantization via random orthogonal rotation + Lloyd-Max per-coordinate scalar quantization.

## New modules

- **`src/rotation.rs`** — `RandomRotation`: d×d orthogonal matrix via Gaussian QR with sign correction
- **`src/mse_quant.rs`** — `mse_quantize`, `mse_dequantize`, `mse_score`, `MseQuantized`

## Design

- `RandomRotation` is a standalone building block (not tied to `QJLSketch`)
- `mse_score` rotates the query once, then dots with dequantized rotated coordinates directly — O(d) per vector, no inverse rotation needed (dot(Π·q, ỹ) = dot(q, Πᵀ·ỹ) by orthogonality)
- Layered for future `turbo.rs`: rotation + codebook + QJL residual correction

## Validation

- 147 tests pass (118 unit + 18 persistence + 11 quality)
- Quality: MSE ranking Kendall's tau > 0.60 for 4-bit, MSE decreases with bits
- `cargo fmt`, `cargo clippy -D warnings`, `cargo doc --no-deps`: all clean