### PR TITLE
feat: add serde support, streaming store export/import, and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mse_score` — score query against quantized vectors (rotate query
     once, dot with dequantized rotated coordinates)
   - `MseQuantized` struct
+- `serde` feature flag — optional `Serialize`/`Deserialize` on public structs
+  - Simple derives on `Codebook`, `MseQuantized`, `CompressedKeys`,
+    `CompressedValues`, `KeysConfig`, `ValuesConfig`, `IndexEntry`, `IndexMeta`
+  - Params-only custom serde on `QJLSketch` and `RandomRotation`
+    (serialize seed + dims, reconstruct matrices on deserialize)
+  - `KeyExportEntry` / `ValueExportEntry` for store export/import
+  - `KeyStore::iter_pages()` / `ValueStore::iter_pages()` — streaming export
+  - `KeyStore::import_entry()` / `ValueStore::import_entry()` — streaming import
+- `seed` field on `QJLSketch` and `RandomRotation` (stored for serialization)
 - 14 new tests (7 rotation + 6 mse_quant + 1 quality)
+- 12 serde round-trip tests (feature-gated)
+- 2 examples: `serde_roundtrip`, `store_export_import`
+- 3 examples: `basic_qjl`, `compressed_scoring`, `mse_quantization`
 
 ## [0.3.0] — 2025-07-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,17 @@ bytemuck = { version = "1.16", features = ["derive"] }
 rayon = "1.10"
 memmap2 = "0.9"
 blake3 = "1.5"
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 approx = "0.5"
 criterion = { version = "0.8", features = ["html_reports"] }
+serde_json = "1"
+
+[features]
+default = []
+serde = ["dep:serde"]
 
 [[bench]]
 name = "score"
@@ -44,6 +50,23 @@ harness = false
 [[bench]]
 name = "store"
 harness = false
+
+[[example]]
+name = "basic_qjl"
+
+[[example]]
+name = "compressed_scoring"
+
+[[example]]
+name = "mse_quantization"
+
+[[example]]
+name = "serde_roundtrip"
+required-features = ["serde"]
+
+[[example]]
+name = "store_export_import"
+required-features = ["serde"]
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ and [QJL](https://github.com/amirzandieh/QJL) (Zandieh et al., 2024).
 
 - **QJL sign-based key compression** — outlier/inlier separation,
   packed 1 bit per projection
+- **Compressed-vs-compressed scoring** — Hamming cosine estimator
+  for page-to-page similarity (no decompression needed)
+- **Lloyd-Max codebook** — optimal scalar quantization for
+  unit-sphere coordinate marginals (1–8 bit)
+- **MSE-optimal quantization** — random rotation + Lloyd-Max
+  per-coordinate (TurboQuant Stage 1)
 - **Min-max value quantization** — 2-bit or 4-bit with i32 bit-packing
 - **Score without decompressing** — signed dot product with
   `sqrt(π/2)/s` scale factor, matches the QJL CUDA kernel
 - **Streaming quantizer** — batch or one-vector-at-a-time compression
 - **Append-only persistence** — mmap-based KeyStore and ValueStore
-  with zero-copy page views
+  with zero-copy page views, streaming export/import
 - **Crash recovery** — truncated tail detection, index rebuild
 - **Compaction** — reclaim dead space with atomic rename
+- **Optional serde** — `Serialize`/`Deserialize` on all public structs
+  (feature-gated behind `serde`)
 
 ## Quick Start
 
@@ -90,26 +98,46 @@ Quality improves with larger sketch_dim.
 
 ## Documentation
 
-| Document                                                 | What it covers                |
-| -------------------------------------------------------- | ----------------------------- |
-| [docs/study.md](docs/study.md)                           | TurboQuant algorithm overview |
-| [docs/design/algorithms.md](docs/design/algorithms.md)   | 7 algorithms with pseudocode  |
-| [docs/design/persistence.md](docs/design/persistence.md) | Two-store file format         |
-| [docs/design/store.md](docs/design/store.md)             | Store API and lifecycle       |
-| [docs/design/benchmarks.md](docs/design/benchmarks.md)   | Benchmark suite and results   |
-| [docs/design/testing.md](docs/design/testing.md)         | Test strategy                 |
-| [docs/roadmap.md](docs/roadmap.md)                       | Development roadmap           |
+| Document                                                    | What it covers                        |
+| ----------------------------------------------------------- | ------------------------------------- |
+| [docs/study.md](docs/study.md)                              | TurboQuant algorithm overview         |
+| [docs/design/algorithms/](docs/design/algorithms/README.md) | Algorithm catalog with pseudocode     |
+| [docs/design/persistence.md](docs/design/persistence.md)    | Two-store file format                 |
+| [docs/design/store.md](docs/design/store.md)                | Store API and lifecycle               |
+| [docs/design/serde.md](docs/design/serde.md)                | Serde support and store export/import |
+| [docs/design/benchmarks.md](docs/design/benchmarks.md)      | Benchmark suite and results           |
+| [docs/design/testing.md](docs/design/testing.md)            | Test strategy                         |
+| [docs/roadmap.md](docs/roadmap.md)                          | Development roadmap                   |
+
+## Examples
+
+| Example                                                | Command                                                    | What it shows                                                     |
+| ------------------------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| [basic_qjl](examples/basic_qjl.rs)                     | `cargo run --example basic_qjl`                            | Compress vectors, score queries, compare with exact dot products  |
+| [compressed_scoring](examples/compressed_scoring.rs)   | `cargo run --example compressed_scoring`                   | Page-to-page similarity via Hamming cosine on sign bits           |
+| [mse_quantization](examples/mse_quantization.rs)       | `cargo run --example mse_quantization`                     | Rotation + Lloyd-Max quantization, 2-bit vs 4-bit MSE comparison  |
+| [serde_roundtrip](examples/serde_roundtrip.rs)         | `cargo run --example serde_roundtrip --features serde`     | Serialize/deserialize Codebook, QJLSketch, RandomRotation to JSON |
+| [store_export_import](examples/store_export_import.rs) | `cargo run --example store_export_import --features serde` | Streaming JSONL export from one KeyStore, import into another     |
 
 ## Building
 
 ```bash
-cargo build                      # debug
-cargo test                       # 93 tests (~8s)
-cargo bench                      # criterion benchmarks (release)
-cargo clippy -- -D warnings      # lint
+cargo build                           # debug
+cargo test                            # all tests (default features)
+cargo test --features serde           # include serde round-trip tests
+cargo bench                           # criterion benchmarks (release)
+cargo clippy -- -D warnings           # lint
+cargo run --example serde_roundtrip --features serde
+cargo run --example store_export_import --features serde
 ```
 
 Requires Rust 1.95+.
+
+### Feature flags
+
+| Flag    | Default | What it enables                                                  |
+| ------- | ------- | ---------------------------------------------------------------- |
+| `serde` | off     | `Serialize`/`Deserialize` on public structs, store export/import |
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Architecture and implementation decisions.
 | [design/store.md](design/store.md)                | Store API usage, lifecycle, error handling, crash safety       |
 | [design/benchmarks.md](design/benchmarks.md)      | Benchmark suite, baseline results, optimization targets        |
 | [design/testing.md](design/testing.md)            | 4-layer test strategy                                          |
+| [design/serde.md](design/serde.md)                | Serde support, feature flag, store export/import               |
 
 ## Guides
 

--- a/docs/design/serde.md
+++ b/docs/design/serde.md
@@ -1,0 +1,72 @@
+# Serde Support
+
+Optional serialization/deserialization for debug dumps, interop,
+and store export/import. Gated behind the `serde` feature flag.
+
+## Usage
+
+```toml
+[dependencies]
+qjl-sketch = { version = "0.4", features = ["serde"] }
+```
+
+## Serializable structs
+
+### Simple derives (data-only)
+
+These serialize all fields directly:
+
+| Struct | Module | Fields |
+|--------|--------|--------|
+| `Codebook` | `codebook` | centroids, boundaries, bit_width |
+| `MseQuantized` | `mse_quant` | indices, num_vectors, dim, bit_width |
+| `CompressedKeys` | `quantize` | sign bits, norms, outlier indices |
+| `CompressedValues` | `values` | packed, scale, mn, etc. |
+| `KeysConfig` | `store::config` | head_dim, sketch_dim, seed, etc. |
+| `ValuesConfig` | `store::config` | bits, group_size |
+| `IndexEntry` | `store::config` | slug_hash, offset, etc. |
+| `IndexMeta` | `store::config` | entry_count, live_bytes, dead_bytes |
+| `KeyExportEntry` | `store::key_store` | slug_hash, content_hash, CompressedKeys |
+| `ValueExportEntry` | `store::value_store` | slug_hash, content_hash, CompressedValues |
+
+### Params-only (reconstructible)
+
+These contain large derived matrices. Only construction params are
+serialized; matrices are reconstructed on deserialize.
+
+| Struct | Serialized fields | Reconstructed |
+|--------|-------------------|---------------|
+| `QJLSketch` | head_dim, sketch_dim, outlier_sketch_dim, seed | proj_dir_score, proj_dir_quant |
+| `RandomRotation` | dim, seed | matrix, matrix_t |
+
+### Not serializable
+
+| Struct | Reason |
+|--------|--------|
+| `KeyStore` / `ValueStore` | File handles, mmap |
+| `KeyPageView` / `ValuePageView` | Borrowed references |
+| `KeyQuantizer` | Borrowed `&QJLSketch` |
+| `CodebookCache` | Runtime cache |
+
+## Store export/import
+
+Streaming export/import avoids loading entire stores into memory.
+
+```rust
+// Export: one entry at a time → JSONL
+let mut out = BufWriter::new(File::create("keys.jsonl")?);
+for entry in store.iter_pages() {
+    serde_json::to_writer(&mut out, &entry)?;
+    out.write_all(b"\n")?;
+}
+
+// Import: one line at a time
+let reader = BufReader::new(File::open("keys.jsonl")?);
+for line in reader.lines() {
+    let entry: KeyExportEntry = serde_json::from_str(&line?)?;
+    store.import_entry(&entry)?;
+}
+```
+
+The crate is format-agnostic — use JSON for debugging, bincode for
+compact transfer, or any other serde-compatible format.

--- a/examples/basic_qjl.rs
+++ b/examples/basic_qjl.rs
@@ -1,0 +1,76 @@
+//! Basic QJL compression and scoring example.
+//!
+//! Run with: `cargo run --example basic_qjl`
+
+use qjl_sketch::outliers::detect_outliers;
+use qjl_sketch::sketch::QJLSketch;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+
+fn random_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+    let normal: StandardNormal = StandardNormal;
+    (0..d)
+        .map(|_| {
+            let v: f64 = normal.sample(rng);
+            v as f32
+        })
+        .collect()
+}
+
+fn main() {
+    let d = 128;
+    let s = 256;
+    let num_keys = 32;
+    let outlier_count = 4;
+
+    // Create a sketch (deterministic from seed)
+    let sketch = QJLSketch::new(d, s, 64, 42).unwrap();
+    println!("Sketch: d={d}, s={s}, seed={}", sketch.seed);
+
+    // Generate random key vectors
+    let mut rng = ChaCha20Rng::seed_from_u64(123);
+    let keys: Vec<f32> = (0..num_keys)
+        .flat_map(|_| random_vec(d, &mut rng))
+        .collect();
+
+    // Detect outlier dimensions and compress
+    let outlier_indices = detect_outliers(&keys, num_keys, d, outlier_count).unwrap();
+    println!("Outlier dims: {outlier_indices:?}");
+
+    let compressed = sketch.quantize(&keys, num_keys, &outlier_indices).unwrap();
+    let bits_per_vector = s; // 1 bit per projection
+    let bytes_per_vector = bits_per_vector / 8;
+    let original_bytes = d * 4; // f32
+    println!(
+        "Compressed {num_keys} vectors: {} bytes/vec (was {} bytes/vec, {:.0}x compression)",
+        bytes_per_vector,
+        original_bytes,
+        original_bytes as f32 / bytes_per_vector as f32
+    );
+
+    // Score a query against compressed keys
+    let query = random_vec(d, &mut rng);
+    let scores = sketch.score(&query, &compressed).unwrap();
+
+    // Compare with exact dot products
+    let exact_scores: Vec<f32> = (0..num_keys)
+        .map(|i| {
+            query
+                .iter()
+                .zip(keys[i * d..(i + 1) * d].iter())
+                .map(|(a, b)| a * b)
+                .sum()
+        })
+        .collect();
+
+    println!("\nTop-5 by approximate score:");
+    let mut ranked: Vec<(usize, f32)> = scores.iter().copied().enumerate().collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    for &(i, approx) in ranked.iter().take(5) {
+        println!(
+            "  vec {i:3}: approx={approx:+.4}, exact={:+.4}",
+            exact_scores[i]
+        );
+    }
+}

--- a/examples/compressed_scoring.rs
+++ b/examples/compressed_scoring.rs
@@ -1,0 +1,56 @@
+//! Compressed-vs-compressed scoring: compare two pages without decompressing.
+//!
+//! Run with: `cargo run --example compressed_scoring`
+
+use qjl_sketch::sketch::QJLSketch;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+
+fn random_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+    let normal: StandardNormal = StandardNormal;
+    (0..d)
+        .map(|_| {
+            let v: f64 = normal.sample(rng);
+            v as f32
+        })
+        .collect()
+}
+
+fn main() {
+    let d = 64;
+    let s = 256;
+    let sketch = QJLSketch::new(d, s, s, 42).unwrap();
+    let mut rng = ChaCha20Rng::seed_from_u64(200);
+
+    // Compress two sets of vectors (e.g. two wiki pages)
+    let num = 8;
+    let page_a: Vec<f32> = (0..num).flat_map(|_| random_vec(d, &mut rng)).collect();
+    let page_b: Vec<f32> = (0..num).flat_map(|_| random_vec(d, &mut rng)).collect();
+
+    let outliers = vec![0u8];
+    let ca = sketch.quantize(&page_a, num, &outliers).unwrap();
+    let cb = sketch.quantize(&page_b, num, &outliers).unwrap();
+
+    // Batch scoring: a[i] vs b[i]
+    let batch_scores = sketch.score_compressed(&ca, &cb).unwrap();
+    println!("Batch scores (a[i] vs b[i]):");
+    for (i, s) in batch_scores.iter().enumerate() {
+        println!("  pair {i}: {s:+.4}");
+    }
+
+    // Cross-pair scoring: any a[i] vs any b[j]
+    println!("\nCross-pair scores (a[0] vs each b[j]):");
+    for j in 0..num {
+        let s = sketch.score_compressed_pair(&ca, 0, &cb, j).unwrap();
+        println!("  a[0] vs b[{j}]: {s:+.4}");
+    }
+
+    // Self-similarity: a[i] vs a[i] should be high (≈ ||v||²)
+    let self_scores = sketch.score_compressed(&ca, &ca).unwrap();
+    println!("\nSelf-similarity (a[i] vs a[i]):");
+    for (i, s) in self_scores.iter().enumerate() {
+        let exact_norm_sq: f32 = page_a[i * d..(i + 1) * d].iter().map(|x| x * x).sum();
+        println!("  vec {i}: score={s:.4}, ||v||²={exact_norm_sq:.4}");
+    }
+}

--- a/examples/mse_quantization.rs
+++ b/examples/mse_quantization.rs
@@ -1,0 +1,69 @@
+//! MSE-optimal quantization: rotation + Lloyd-Max per-coordinate.
+//!
+//! Run with: `cargo run --example mse_quantization`
+
+use qjl_sketch::codebook::generate_codebook;
+use qjl_sketch::mse_quant::{mse_dequantize, mse_quantize, mse_score};
+use qjl_sketch::rotation::RandomRotation;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+
+fn random_unit_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+    let normal: StandardNormal = StandardNormal;
+    let mut v: Vec<f32> = (0..d)
+        .map(|_| {
+            let x: f64 = normal.sample(rng);
+            x as f32
+        })
+        .collect();
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    v.iter_mut().for_each(|x| *x /= norm);
+    v
+}
+
+fn main() {
+    let dim = 128;
+    let mut rng = ChaCha20Rng::seed_from_u64(42);
+
+    let rot = RandomRotation::new(dim, 77).unwrap();
+    println!("RandomRotation: dim={dim}, seed={}", rot.seed);
+
+    // Compare 2-bit vs 4-bit quantization
+    for bits in [2, 4] {
+        let cb = generate_codebook(dim, bits, 100).unwrap();
+        println!("\n--- {bits}-bit codebook ({} levels) ---", cb.num_levels());
+
+        // Quantize a unit vector
+        let v = random_unit_vec(dim, &mut rng);
+        let quantized = mse_quantize(&v, 1, &rot, &cb).unwrap();
+        let reconstructed = mse_dequantize(&quantized, &rot, &cb).unwrap();
+
+        // MSE
+        let mse: f32 = v
+            .iter()
+            .zip(reconstructed.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / dim as f32;
+        println!("MSE per dimension: {mse:.6}");
+
+        // Score accuracy
+        let query = random_unit_vec(dim, &mut rng);
+        let exact: f32 = query.iter().zip(v.iter()).map(|(a, b)| a * b).sum();
+        let scores = mse_score(&query, &quantized, &rot, &cb).unwrap();
+        let error = (scores[0] - exact).abs();
+        println!(
+            "Score: approx={:.4}, exact={exact:.4}, error={error:.4}",
+            scores[0]
+        );
+
+        // Storage
+        let bytes = quantized.indices.len() * bits as usize / 8;
+        let original = dim * 4;
+        println!(
+            "Storage: {bytes} bytes ({:.0}x compression)",
+            original as f32 / bytes as f32
+        );
+    }
+}

--- a/examples/serde_roundtrip.rs
+++ b/examples/serde_roundtrip.rs
@@ -1,0 +1,38 @@
+//! Serde round-trip example: serialize and deserialize core structs to JSON.
+//!
+//! Run with: `cargo run --example serde_roundtrip --features serde`
+
+use qjl_sketch::codebook::generate_codebook;
+use qjl_sketch::rotation::RandomRotation;
+use qjl_sketch::sketch::QJLSketch;
+
+fn main() {
+    // Codebook
+    let cb = generate_codebook(64, 4, 100).unwrap();
+    let json = serde_json::to_string_pretty(&cb).unwrap();
+    println!(
+        "Codebook JSON ({} bytes):\n{}\n",
+        json.len(),
+        &json[..200.min(json.len())]
+    );
+    let cb2: qjl_sketch::codebook::Codebook = serde_json::from_str(&json).unwrap();
+    assert_eq!(cb.centroids, cb2.centroids);
+    println!("✓ Codebook round-trip OK\n");
+
+    // QJLSketch — serializes as params only, reconstructs matrices
+    let sketch = QJLSketch::new(64, 128, 32, 42).unwrap();
+    let json = serde_json::to_string_pretty(&sketch).unwrap();
+    println!("QJLSketch JSON ({} bytes):\n{}\n", json.len(), json);
+    let s2: QJLSketch = serde_json::from_str(&json).unwrap();
+    assert_eq!(sketch.proj_dir_score, s2.proj_dir_score);
+    println!("✓ QJLSketch round-trip OK (matrices reconstructed from seed)\n");
+
+    // RandomRotation — same pattern
+    let rot = RandomRotation::new(32, 99).unwrap();
+    let json = serde_json::to_string_pretty(&rot).unwrap();
+    println!("RandomRotation JSON ({} bytes):\n{}\n", json.len(), json);
+    let r2: RandomRotation = serde_json::from_str(&json).unwrap();
+    let x: Vec<f32> = (0..32).map(|i| i as f32).collect();
+    assert_eq!(rot.rotate(&x).unwrap(), r2.rotate(&x).unwrap());
+    println!("✓ RandomRotation round-trip OK\n");
+}

--- a/examples/store_export_import.rs
+++ b/examples/store_export_import.rs
@@ -1,0 +1,81 @@
+//! Store export/import example: streaming JSONL export from one KeyStore,
+//! import into another, verify scores match.
+//!
+//! Run with: `cargo run --example store_export_import --features serde`
+
+use qjl_sketch::store::config::KeysConfig;
+use qjl_sketch::store::key_store::{KeyExportEntry, KeyStore};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use tempfile::tempdir;
+
+fn random_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+    let normal: StandardNormal = StandardNormal;
+    (0..d)
+        .map(|_| {
+            let v: f64 = normal.sample(rng);
+            v as f32
+        })
+        .collect()
+}
+
+fn main() {
+    let config = KeysConfig {
+        head_dim: 16,
+        sketch_dim: 32,
+        outlier_sketch_dim: 16,
+        seed: 42,
+    };
+    let sketch = config.build_sketch();
+
+    // Create source store with 10 pages
+    let dir_src = tempdir().unwrap();
+    let mut store_src = KeyStore::create(dir_src.path(), config.clone()).unwrap();
+    let mut rng = ChaCha20Rng::seed_from_u64(123);
+    for slug in 0u64..10 {
+        let keys = random_vec(4 * 16, &mut rng);
+        let compressed = sketch.quantize(&keys, 4, &[0u8]).unwrap();
+        store_src.append(slug, slug * 100, &compressed).unwrap();
+    }
+    println!("Source store: {} pages", store_src.len());
+
+    // Export to JSONL file (streaming — one line per entry)
+    let dump_path = dir_src.path().join("keys.jsonl");
+    {
+        let file = std::fs::File::create(&dump_path).unwrap();
+        let mut writer = BufWriter::new(file);
+        for entry in store_src.iter_pages() {
+            serde_json::to_writer(&mut writer, &entry).unwrap();
+            writer.write_all(b"\n").unwrap();
+        }
+        writer.flush().unwrap();
+    }
+    let dump_size = std::fs::metadata(&dump_path).unwrap().len();
+    println!("Exported to JSONL: {} bytes", dump_size);
+
+    // Import from JSONL into a new store (streaming — one line at a time)
+    let dir_dst = tempdir().unwrap();
+    let mut store_dst = KeyStore::create(dir_dst.path(), config).unwrap();
+    {
+        let file = std::fs::File::open(&dump_path).unwrap();
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let entry: KeyExportEntry = serde_json::from_str(&line.unwrap()).unwrap();
+            store_dst.import_entry(&entry).unwrap();
+        }
+    }
+    println!("Imported into destination store: {} pages", store_dst.len());
+
+    // Verify scores match
+    let query = random_vec(16, &mut rng);
+    for slug in 0u64..10 {
+        let ck_src = store_src.get_page(slug).unwrap().to_compressed_keys(16);
+        let ck_dst = store_dst.get_page(slug).unwrap().to_compressed_keys(16);
+        let s1 = sketch.score(&query, &ck_src).unwrap();
+        let s2 = sketch.score(&query, &ck_dst).unwrap();
+        assert_eq!(s1, s2, "score mismatch for slug {slug}");
+    }
+    println!("✓ All scores match between source and destination stores");
+}

--- a/src/codebook.rs
+++ b/src/codebook.rs
@@ -15,6 +15,7 @@ use crate::math::{beta_pdf, sample_beta_marginal, simpson_integrate};
 /// 2^bit_width - 1 decision boundaries, optimized for the Beta(1/2, (d-1)/2)
 /// coordinate marginal of unit-sphere-uniform vectors.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Codebook {
     /// Quantization centroids (reconstruction values), length = 2^bit_width.
     pub centroids: Vec<f32>,

--- a/src/mse_quant.rs
+++ b/src/mse_quant.rs
@@ -10,6 +10,7 @@ use crate::rotation::RandomRotation;
 
 /// MSE-quantized vectors: per-coordinate codebook indices after rotation.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MseQuantized {
     /// Codebook indices, flattened \[num_vectors × dim\].
     pub indices: Vec<u8>,

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -4,6 +4,7 @@ use crate::sketch::{l2_norm, QJLSketch};
 
 /// Compressed key vectors — packed sign bits with outlier separation.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompressedKeys {
     /// Packed sign bits for inlier dimensions \[num_vectors, sketch_dim/8\].
     pub key_quant: Vec<u8>,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -24,6 +24,8 @@ pub struct RandomRotation {
     matrix_t: Vec<f32>,
     /// Vector dimension.
     pub dim: usize,
+    /// RNG seed used to generate the rotation (stored for serialization).
+    pub seed: u64,
 }
 
 impl RandomRotation {
@@ -70,6 +72,7 @@ impl RandomRotation {
             matrix,
             matrix_t,
             dim,
+            seed,
         })
     }
 
@@ -110,6 +113,35 @@ fn matvec_square(mat: &[f32], dim: usize, x: &[f32]) -> Vec<f32> {
         out[r] = acc;
     }
     out
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::RandomRotation;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    struct RandomRotationParams {
+        dim: usize,
+        seed: u64,
+    }
+
+    impl Serialize for RandomRotation {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            RandomRotationParams {
+                dim: self.dim,
+                seed: self.seed,
+            }
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for RandomRotation {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let p = RandomRotationParams::deserialize(deserializer)?;
+            RandomRotation::new(p.dim, p.seed).map_err(serde::de::Error::custom)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -14,6 +14,8 @@ pub struct QJLSketch {
     pub head_dim: usize,
     pub sketch_dim: usize,
     pub outlier_sketch_dim: usize,
+    /// RNG seed used to generate the projection (stored for serialization).
+    pub seed: u64,
     /// Orthogonalized projection matrix [head_dim, sketch_dim], row-major.
     /// Used to sketch queries: sketched_q = query @ proj_dir_score.
     pub proj_dir_score: Vec<f32>,
@@ -61,6 +63,7 @@ impl QJLSketch {
             head_dim,
             sketch_dim,
             outlier_sketch_dim,
+            seed,
             proj_dir_score,
             proj_dir_quant,
         })
@@ -143,6 +146,40 @@ pub fn matvec(mat: &[f32], rows: usize, cols: usize, vec: &[f32]) -> Vec<f32> {
 /// Compute the vector L2 norm.
 pub fn l2_norm(v: &[f32]) -> f32 {
     v.iter().map(|x| x * x).sum::<f32>().sqrt()
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::QJLSketch;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize)]
+    struct QJLSketchParams {
+        head_dim: usize,
+        sketch_dim: usize,
+        outlier_sketch_dim: usize,
+        seed: u64,
+    }
+
+    impl Serialize for QJLSketch {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            QJLSketchParams {
+                head_dim: self.head_dim,
+                sketch_dim: self.sketch_dim,
+                outlier_sketch_dim: self.outlier_sketch_dim,
+                seed: self.seed,
+            }
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for QJLSketch {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let p = QJLSketchParams::deserialize(deserializer)?;
+            QJLSketch::new(p.head_dim, p.sketch_dim, p.outlier_sketch_dim, p.seed)
+                .map_err(serde::de::Error::custom)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/store/config.rs
+++ b/src/store/config.rs
@@ -10,6 +10,7 @@ pub const VALUE_ENTRY_MAGIC: &[u8; 4] = b"TQVE";
 pub const INDEX_VERSION: u16 = 1;
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeysConfig {
     pub head_dim: u16,
     pub sketch_dim: u16,
@@ -61,6 +62,7 @@ impl KeysConfig {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuesConfig {
     pub bits: u8,
     pub group_size: u16,
@@ -96,6 +98,7 @@ impl ValuesConfig {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexEntry {
     pub slug_hash: u64,
     pub offset: u64,
@@ -128,6 +131,7 @@ impl IndexEntry {
 }
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexMeta {
     pub entry_count: u16,
     pub live_bytes: u32,

--- a/src/store/key_store.rs
+++ b/src/store/key_store.rs
@@ -353,6 +353,36 @@ impl KeyStore {
     }
 }
 
+// ── Export / Import ───────────────────────────────────────────────────────────
+
+/// A single key page entry for export/import.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct KeyExportEntry {
+    pub slug_hash: u64,
+    pub content_hash: u64,
+    pub compressed: CompressedKeys,
+}
+
+impl KeyStore {
+    /// Iterate over all pages, yielding export entries one at a time.
+    pub fn iter_pages(&self) -> impl Iterator<Item = KeyExportEntry> + '_ {
+        self.index.iter().filter_map(|entry| {
+            let page = self.get_page(entry.slug_hash)?;
+            Some(KeyExportEntry {
+                slug_hash: entry.slug_hash,
+                content_hash: entry.content_hash,
+                compressed: page.to_compressed_keys(self.config.head_dim as usize),
+            })
+        })
+    }
+
+    /// Import a single export entry into the store.
+    pub fn import_entry(&mut self, entry: &KeyExportEntry) -> Result<()> {
+        self.append(entry.slug_hash, entry.content_hash, &entry.compressed)
+    }
+}
+
 // ── Entry serialization ───────────────────────────────────────────────────────
 
 /// Truncate a .bin file to the last valid entry.

--- a/src/store/value_store.rs
+++ b/src/store/value_store.rs
@@ -278,6 +278,36 @@ impl ValueStore {
     }
 }
 
+// ── Export / Import ───────────────────────────────────────────────────────────
+
+/// A single value page entry for export/import.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ValueExportEntry {
+    pub slug_hash: u64,
+    pub content_hash: u64,
+    pub compressed: CompressedValues,
+}
+
+impl ValueStore {
+    /// Iterate over all pages, yielding export entries one at a time.
+    pub fn iter_pages(&self) -> impl Iterator<Item = ValueExportEntry> + '_ {
+        self.index.iter().filter_map(|entry| {
+            let page = self.get_page(entry.slug_hash)?;
+            Some(ValueExportEntry {
+                slug_hash: entry.slug_hash,
+                content_hash: entry.content_hash,
+                compressed: page.to_compressed_values(),
+            })
+        })
+    }
+
+    /// Import a single export entry into the store.
+    pub fn import_entry(&mut self, entry: &ValueExportEntry) -> Result<()> {
+        self.append(entry.slug_hash, entry.content_hash, &entry.compressed)
+    }
+}
+
 // ── Entry serialization ───────────────────────────────────────────────────────
 
 /// Truncate a .bin file to the last valid entry.

--- a/src/values.rs
+++ b/src/values.rs
@@ -2,6 +2,7 @@ use crate::error::{validate_finite, QjlError, Result};
 
 /// Compressed value vectors — min-max quantized and bit-packed.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompressedValues {
     /// Bit-packed quantized values. Layout depends on bits.
     pub packed: Vec<i32>,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,238 @@
+#![cfg(feature = "serde")]
+
+use qjl_sketch::codebook::{generate_codebook, Codebook};
+use qjl_sketch::mse_quant::{mse_quantize, MseQuantized};
+use qjl_sketch::quantize::CompressedKeys;
+use qjl_sketch::rotation::RandomRotation;
+use qjl_sketch::sketch::QJLSketch;
+use qjl_sketch::store::config::{IndexEntry, IndexMeta, KeysConfig, ValuesConfig};
+use qjl_sketch::store::key_store::{KeyExportEntry, KeyStore};
+use qjl_sketch::store::value_store::{ValueExportEntry, ValueStore};
+use qjl_sketch::values::{quantize_values, CompressedValues};
+
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_distr::{Distribution, StandardNormal};
+use tempfile::tempdir;
+
+fn random_vec(d: usize, rng: &mut ChaCha20Rng) -> Vec<f32> {
+    let normal: StandardNormal = StandardNormal;
+    (0..d)
+        .map(|_| {
+            let v: f64 = normal.sample(rng);
+            v as f32
+        })
+        .collect()
+}
+
+// ── Data struct round-trips ──────────────────────────────────────────────────
+
+#[test]
+fn codebook_roundtrip() {
+    let cb = generate_codebook(64, 4, 50).unwrap();
+    let json = serde_json::to_string(&cb).unwrap();
+    let cb2: Codebook = serde_json::from_str(&json).unwrap();
+    assert_eq!(cb.centroids, cb2.centroids);
+    assert_eq!(cb.boundaries, cb2.boundaries);
+    assert_eq!(cb.bit_width, cb2.bit_width);
+}
+
+#[test]
+fn compressed_keys_roundtrip() {
+    let sketch = QJLSketch::new(16, 32, 16, 42).unwrap();
+    let mut rng = ChaCha20Rng::seed_from_u64(1);
+    let keys = random_vec(4 * 16, &mut rng);
+    let compressed = sketch.quantize(&keys, 4, &[0u8, 1]).unwrap();
+
+    let json = serde_json::to_string(&compressed).unwrap();
+    let c2: CompressedKeys = serde_json::from_str(&json).unwrap();
+    assert_eq!(compressed.key_quant, c2.key_quant);
+    assert_eq!(compressed.key_norms, c2.key_norms);
+    assert_eq!(compressed.num_vectors, c2.num_vectors);
+}
+
+#[test]
+fn compressed_values_roundtrip() {
+    let values: Vec<f32> = (0..16).map(|i| i as f32 * 0.5).collect();
+    let compressed = quantize_values(&values, 8, 4).unwrap();
+
+    let json = serde_json::to_string(&compressed).unwrap();
+    let c2: CompressedValues = serde_json::from_str(&json).unwrap();
+    assert_eq!(compressed.packed, c2.packed);
+    assert_eq!(compressed.scale, c2.scale);
+    assert_eq!(compressed.mn, c2.mn);
+    assert_eq!(compressed.num_elements, c2.num_elements);
+}
+
+#[test]
+fn mse_quantized_roundtrip() {
+    let rot = RandomRotation::new(32, 42).unwrap();
+    let cb = generate_codebook(32, 3, 50).unwrap();
+    let mut rng = ChaCha20Rng::seed_from_u64(2);
+    let v = random_vec(32, &mut rng);
+    let q = mse_quantize(&v, 1, &rot, &cb).unwrap();
+
+    let json = serde_json::to_string(&q).unwrap();
+    let q2: MseQuantized = serde_json::from_str(&json).unwrap();
+    assert_eq!(q.indices, q2.indices);
+    assert_eq!(q.dim, q2.dim);
+    assert_eq!(q.bit_width, q2.bit_width);
+}
+
+#[test]
+fn keys_config_roundtrip() {
+    let config = KeysConfig {
+        head_dim: 128,
+        sketch_dim: 256,
+        outlier_sketch_dim: 64,
+        seed: 42,
+    };
+    let json = serde_json::to_string(&config).unwrap();
+    let c2: KeysConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, c2);
+}
+
+#[test]
+fn values_config_roundtrip() {
+    let config = ValuesConfig {
+        bits: 4,
+        group_size: 32,
+    };
+    let json = serde_json::to_string(&config).unwrap();
+    let c2: ValuesConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, c2);
+}
+
+#[test]
+fn index_entry_roundtrip() {
+    let entry = IndexEntry {
+        slug_hash: 0xDEAD,
+        offset: 1024,
+        entry_len: 500,
+        generation: 3,
+        content_hash: 0xBEEF,
+    };
+    let json = serde_json::to_string(&entry).unwrap();
+    let e2: IndexEntry = serde_json::from_str(&json).unwrap();
+    assert_eq!(entry, e2);
+}
+
+#[test]
+fn index_meta_roundtrip() {
+    let meta = IndexMeta {
+        entry_count: 42,
+        live_bytes: 10000,
+        dead_bytes: 500,
+    };
+    let json = serde_json::to_string(&meta).unwrap();
+    let m2: IndexMeta = serde_json::from_str(&json).unwrap();
+    assert_eq!(meta.entry_count, m2.entry_count);
+    assert_eq!(meta.live_bytes, m2.live_bytes);
+    assert_eq!(meta.dead_bytes, m2.dead_bytes);
+}
+
+// ── Reconstructible struct round-trips ───────────────────────────────────────
+
+#[test]
+fn qjl_sketch_roundtrip() {
+    let sketch = QJLSketch::new(64, 128, 32, 42).unwrap();
+    let json = serde_json::to_string(&sketch).unwrap();
+    let s2: QJLSketch = serde_json::from_str(&json).unwrap();
+    assert_eq!(sketch.head_dim, s2.head_dim);
+    assert_eq!(sketch.sketch_dim, s2.sketch_dim);
+    assert_eq!(sketch.seed, s2.seed);
+    assert_eq!(sketch.proj_dir_score, s2.proj_dir_score);
+    assert_eq!(sketch.proj_dir_quant, s2.proj_dir_quant);
+}
+
+#[test]
+fn random_rotation_roundtrip() {
+    let rot = RandomRotation::new(32, 99).unwrap();
+    let json = serde_json::to_string(&rot).unwrap();
+    let r2: RandomRotation = serde_json::from_str(&json).unwrap();
+    assert_eq!(rot.dim, r2.dim);
+    assert_eq!(rot.seed, r2.seed);
+    // Matrices are reconstructed from seed — verify via rotate
+    let x: Vec<f32> = (0..32).map(|i| i as f32).collect();
+    let y1 = rot.rotate(&x).unwrap();
+    let y2 = r2.rotate(&x).unwrap();
+    assert_eq!(y1, y2);
+}
+
+// ── Store export/import round-trips ──────────────────────────────────────────
+
+#[test]
+fn key_store_export_import_roundtrip() {
+    let dir_src = tempdir().unwrap();
+    let dir_dst = tempdir().unwrap();
+    let config = KeysConfig {
+        head_dim: 16,
+        sketch_dim: 32,
+        outlier_sketch_dim: 16,
+        seed: 42,
+    };
+    let sketch = config.build_sketch();
+    let mut store_src = KeyStore::create(dir_src.path(), config.clone()).unwrap();
+
+    let mut rng = ChaCha20Rng::seed_from_u64(500);
+    for slug in 0u64..5 {
+        let keys = random_vec(4 * 16, &mut rng);
+        let compressed = sketch.quantize(&keys, 4, &[0u8]).unwrap();
+        store_src.append(slug, slug * 100, &compressed).unwrap();
+    }
+
+    // Export → serialize → deserialize → import
+    let mut store_dst = KeyStore::create(dir_dst.path(), config.clone()).unwrap();
+    for entry in store_src.iter_pages() {
+        let json = serde_json::to_string(&entry).unwrap();
+        let entry2: KeyExportEntry = serde_json::from_str(&json).unwrap();
+        store_dst.import_entry(&entry2).unwrap();
+    }
+
+    assert_eq!(store_dst.len(), 5);
+
+    // Verify scores match
+    let query = random_vec(16, &mut rng);
+    for slug in 0u64..5 {
+        let page_src = store_src.get_page(slug).unwrap();
+        let page_dst = store_dst.get_page(slug).unwrap();
+        let ck_src = page_src.to_compressed_keys(16);
+        let ck_dst = page_dst.to_compressed_keys(16);
+        let scores_src = sketch.score(&query, &ck_src).unwrap();
+        let scores_dst = sketch.score(&query, &ck_dst).unwrap();
+        assert_eq!(scores_src, scores_dst);
+    }
+}
+
+#[test]
+fn value_store_export_import_roundtrip() {
+    let dir_src = tempdir().unwrap();
+    let dir_dst = tempdir().unwrap();
+    let config = ValuesConfig {
+        bits: 4,
+        group_size: 8,
+    };
+    let mut store_src = ValueStore::create(dir_src.path(), config.clone()).unwrap();
+
+    for slug in 0u64..5 {
+        let values: Vec<f32> = (0..8).map(|i| (slug as f32) + i as f32).collect();
+        let compressed = quantize_values(&values, 8, 4).unwrap();
+        store_src.append(slug, slug * 10, &compressed).unwrap();
+    }
+
+    let mut store_dst = ValueStore::create(dir_dst.path(), config).unwrap();
+    for entry in store_src.iter_pages() {
+        let json = serde_json::to_string(&entry).unwrap();
+        let entry2: ValueExportEntry = serde_json::from_str(&json).unwrap();
+        store_dst.import_entry(&entry2).unwrap();
+    }
+
+    assert_eq!(store_dst.len(), 5);
+    for slug in 0u64..5 {
+        let p_src = store_src.get_page(slug).unwrap();
+        let p_dst = store_dst.get_page(slug).unwrap();
+        assert_eq!(p_src.packed(), p_dst.packed());
+        assert_eq!(p_src.scale(), p_dst.scale());
+        assert_eq!(p_src.mn(), p_dst.mn());
+    }
+}


### PR DESCRIPTION
## Summary

Optional `serde` feature flag for serialization/deserialization on all public structs, plus streaming store export/import and 5 runnable examples.

## Serde support (`--features serde`)

- **Simple derives** on 8 data structs: `Codebook`, `MseQuantized`, `CompressedKeys`, `CompressedValues`, `KeysConfig`, `ValuesConfig`, `IndexEntry`, `IndexMeta`
- **Params-only custom serde** on `QJLSketch` and `RandomRotation` — serialize seed + dims, reconstruct matrices on deserialize
- **`seed` field** added to `QJLSketch` and `RandomRotation` (stored for serialization)

## Store export/import (streaming)

- `KeyStore::iter_pages()` / `ValueStore::iter_pages()` — streaming export, one entry at a time
- `KeyStore::import_entry()` / `ValueStore::import_entry()` — streaming import
- `KeyExportEntry` / `ValueExportEntry` structs with serde derives

## Examples

| Example | Features | What it shows |
|---------|----------|---------------|
| `basic_qjl` | default | Compress, score, compare with exact |
| `compressed_scoring` | default | Page-to-page Hamming cosine similarity |
| `mse_quantization` | default | Rotation + Lloyd-Max, 2-bit vs 4-bit |
| `serde_roundtrip` | serde | JSON serialize/deserialize core structs |
| `store_export_import` | serde | Streaming JSONL export/import between stores |

## Validation

- 147 tests pass (default features)
- 159 tests pass (`--features serde`, +12 serde round-trip tests)
- All 5 examples run successfully
- `cargo fmt`, `cargo clippy -D warnings`, `cargo doc --no-deps`: all clean